### PR TITLE
Adds fixes for compile time build errors 

### DIFF
--- a/sapi/include/rsi_ble_apis.h
+++ b/sapi/include/rsi_ble_apis.h
@@ -1076,11 +1076,21 @@ int32_t rsi_ble_encrypt(uint8_t *, uint8_t *, uint8_t *);
  * */
 int32_t rsi_ble_stop_advertising(void);
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*==============================================*/
 /**
  * @fn         rsi_ble_set_advertise_data
  * */
 int32_t rsi_ble_set_advertise_data(uint8_t *data, uint16_t data_len);
+#ifdef __cplusplus
+}
+#endif
+
+
+
 
 /*========================================================*/
 /**

--- a/sapi/include/rsi_ble_apis.h
+++ b/sapi/include/rsi_ble_apis.h
@@ -1035,7 +1035,9 @@ typedef struct chip_ble_buffers_stats_s {
 /******************************************************
  * *              GAP API's Declarations
  * ******************************************************/
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 //*==============================================*/
 /**
  * @fn         rsi_convert_db_to_powindex
@@ -2404,4 +2406,7 @@ int32_t rsi_ble_mtu_exchange_resp(uint8_t *dev_addr, uint8_t mtu_size);
 void rsi_ble_gap_extended_register_callbacks(rsi_ble_on_remote_features_t ble_on_remote_features_event,
                                              rsi_ble_on_le_more_data_req_t ble_on_le_more_data_req_event);
 int32_t rsi_ble_set_wo_resp_notify_buf_info(uint8_t *dev_addr, uint8_t buf_mode, uint8_t buf_cnt);
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sapi/include/rsi_bt_apis.h
+++ b/sapi/include/rsi_bt_apis.h
@@ -3709,7 +3709,7 @@ int32_t rsi_bt_spp_transfer(uint8_t *remote_dev_addr, uint8_t *data, uint16_t le
 int32_t rsi_bt_hfp_init(void);
 int32_t rsi_bt_hfp_connect(uint8_t *remote_dev_addr);
 int32_t rsi_bt_hfp_disconnect(uint8_t *remote_dev_addr);
-int32_t rsi_bt_hfp_phoneoperator(uint8_t *oprat);
+//int32_t rsi_bt_hfp_phoneoperator(uint8_t *operator);
 int32_t rsi_bt_hfp_callaccept(void);
 int32_t rsi_bt_hfp_callreject(void);
 int32_t rsi_bt_hfp_dialnum(uint8_t *phone_no);

--- a/sapi/include/rsi_bt_apis.h
+++ b/sapi/include/rsi_bt_apis.h
@@ -3709,7 +3709,7 @@ int32_t rsi_bt_spp_transfer(uint8_t *remote_dev_addr, uint8_t *data, uint16_t le
 int32_t rsi_bt_hfp_init(void);
 int32_t rsi_bt_hfp_connect(uint8_t *remote_dev_addr);
 int32_t rsi_bt_hfp_disconnect(uint8_t *remote_dev_addr);
-int32_t rsi_bt_hfp_phoneoperator(uint8_t *operator);
+int32_t rsi_bt_hfp_phoneoperator(uint8_t *oprat);
 int32_t rsi_bt_hfp_callaccept(void);
 int32_t rsi_bt_hfp_callreject(void);
 int32_t rsi_bt_hfp_dialnum(uint8_t *phone_no);

--- a/sapi/include/rsi_bt_common_apis.h
+++ b/sapi/include/rsi_bt_common_apis.h
@@ -58,6 +58,9 @@
  * @fn          int32_t rsi_bt_set_bd_addr(uint8_t *dev_addr)
  *              
  */
+#ifdef __cplusplus
+extern "C" {
+#endif
 int32_t rsi_bt_set_bd_addr(uint8_t *dev_addr);
 
 /*==============================================*/
@@ -156,5 +159,7 @@ int32_t rsi_bt_set_antenna_tx_power_level(uint8_t protocol_mode, int8_t tx_power
 int32_t rsi_bt_get_bt_stack_version(rsi_bt_resp_get_bt_stack_version_t *bt_resp_get_bt_stack_version);
 
 int32_t rsi_bt_power_save_profile(uint8_t psp_mode, uint8_t psp_type);
-
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sapi/include/rsi_bt_common_apis.h
+++ b/sapi/include/rsi_bt_common_apis.h
@@ -65,7 +65,7 @@ int32_t rsi_bt_set_bd_addr(uint8_t *dev_addr);
  * @fn          int32_t rsi_bt_ber_enable(struct rsi_bt_ber_cmd_s *rsi_bt_ber_cmd)
  *
  */
-int32_t rsi_bt_ber_enable_or_disable(struct rsi_bt_ber_cmd_s *ber_cmd);
+int32_t rsi_bt_ber_enable_or_disable(rsi_bt_ber_cmd_t *ber_cmd);
 
 /*==============================================*/
 /**

--- a/sapi/include/rsi_bt_common_config.h
+++ b/sapi/include/rsi_bt_common_config.h
@@ -155,8 +155,8 @@
 #ifndef BIN_FILE
 #define BIN_FILE 1
 #endif
-#ifndef ARRAY
-#define ARRAY 2
+#ifndef BT_ARRAY
+#define BT_ARRAY 2
 #endif
 #ifndef SD_BIN_FILE
 #define SD_BIN_FILE 3

--- a/sapi/include/rsi_socket.h
+++ b/sapi/include/rsi_socket.h
@@ -83,7 +83,10 @@
 #define PF_INET  AF_INET
 #define PF_INET6 AF_INET6
 
+#ifndef INADDR_ANY
 #define INADDR_ANY              0
+#endif
+
 #define BSD_LOCAL_IF_INADDR_ANY 0xFFFFFFFF
 /* Define API error codes.  */
 
@@ -416,8 +419,14 @@ struct rsi_in6_addr {
   } _S6_un;
 };
 
+
+#ifndef s6_addr
 #define s6_addr   _S6_un._S6_u8
+#endif
+
+#ifndef s6_addr32
 #define s6_addr32 _S6_un._S6_u32
+#endif
 
 struct rsi_sockaddr_in6 {
   uint16_t sin6_family;          /* AF_INET6 */

--- a/sapi/include/rsi_wlan.h
+++ b/sapi/include/rsi_wlan.h
@@ -828,7 +828,7 @@ typedef struct rsi_req_cert_valid_s {
 
 } rsi_req_cert_valid_t;
 #endif
-//#define RSI_CERT_MAX_DATA_SIZE (RSI_MAX_CERT_SEND_SIZE – sizeof(struct rsi_cert_info_s))
+#define RSI_CERT_MAX_DATA_SIZE (RSI_MAX_CERT_SEND_SIZE - (sizeof(struct rsi_cert_info_s)))
 // Set certificate command request structure
 typedef struct rsi_req_set_certificate_s {
   // certificate information structure

--- a/sapi/include/rsi_wlan.h
+++ b/sapi/include/rsi_wlan.h
@@ -828,7 +828,7 @@ typedef struct rsi_req_cert_valid_s {
 
 } rsi_req_cert_valid_t;
 #endif
-#define RSI_CERT_MAX_DATA_SIZE (RSI_MAX_CERT_SEND_SIZE – (sizeof(struct rsi_cert_info_s)))
+//#define RSI_CERT_MAX_DATA_SIZE (RSI_MAX_CERT_SEND_SIZE – sizeof(struct rsi_cert_info_s))
 // Set certificate command request structure
 typedef struct rsi_req_set_certificate_s {
   // certificate information structure

--- a/sapi/include/rsi_wlan_non_rom.h
+++ b/sapi/include/rsi_wlan_non_rom.h
@@ -383,24 +383,24 @@ struct rsi_bit_2_string {
   char *string;
 };
 static const struct rsi_bit_2_string STATE[WLAN_MODULE_STATES] = {
-  { 0x10, "Beacon Loss (Failover Roam)" },
-  { 0x20, "De-authentication (AP induced Roam / Disconnect from supplicant" },
-  { 0x50, "Current AP is best" },
-  { 0x60, "Better AP found" },
-  { 0x70, "No AP found" },
-  { 0x80, "Associated" },
-  { 0x90, "Unassociated" },
-  { 0x01, "Authentication denial" },
-  { 0x02, "Association denial" },
-  { 0x03, "AP not present" },
-  { 0x05, "WPA2 key exchange failed" }
+  { 0x10, (char *)"Beacon Loss (Failover Roam)" },
+  { 0x20, (char *)"De-authentication (AP induced Roam / Disconnect from supplicant" },
+  { 0x50, (char *)"Current AP is best" },
+  { 0x60, (char *)"Better AP found" },
+  { 0x70, (char *)"No AP found" },
+  { 0x80, (char *)"Associated" },
+  { 0x90, (char *)"Unassociated" },
+  { 0x01, (char *)"Authentication denial" },
+  { 0x02, (char *)"Association denial" },
+  { 0x03, (char *)"AP not present" },
+  { 0x05, (char *)"WPA2 key exchange failed" }
 
 };
 
 static const struct rsi_bit_2_string REASONCODE[WLAN_REASON_CODES] = {
-  { 0x01, "Authentication denial" },       { 0x02, "Association denial" },
-  { 0x10, "Beacon Loss (Failover Roam)" }, { 0x20, "De-authentication (AP induced Roam/Deauth from supplicant)" },
-  { 0x07, "PSK not configured" },          { 0x05, "Roaming not enabled" },
+  { 0x01, (char *)"Authentication denial" },       { 0x02, (char *)"Association denial" },
+  { 0x10, (char *)"Beacon Loss (Failover Roam)" }, { 0x20, (char *)"De-authentication (AP induced Roam/Deauth from supplicant)" },
+  { 0x07, (char *)"PSK not configured" },          { 0x05, (char *)"Roaming not enabled" },
 
 };
 


### PR DESCRIPTION
Fixes:

1. Fix in the rsi_wlan.h replaced hyphen(-) by Minus character.
2. "operator" keyword is used in rsi_bt_apis.h for rsi_bt_hfp_phoneoperator API currently it's commented because BT is not used in the matter I'm discussing this with BT team
3. Other are the enhancement in the current code 